### PR TITLE
[Feat] Remove OkHttp3 and use the included HttpClient

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,6 @@ dependencies {
     compileOnly(libs.configlib.paper)
     compileOnly(libs.lombok)
     annotationProcessor(libs.lombok)
-    implementation("com.squareup.okhttp3:okhttp:5.0.0-alpha.3")
 }
 
 group = "de.outdev.totemguard"


### PR DESCRIPTION
This PR aims to add an update to the webhook implementation where the use of OkHttp3 isn't needed.